### PR TITLE
fix: Always set the Authorization token

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,6 @@ can be used to automatically bump the version number and generate the changelog.
 
 ## Credits
 
+This project was created with the help of [this python packaging documentation](https://py-pkgs.org/01-introduction).
+
 `ghgql` was created with [`cookiecutter`](https://cookiecutter.readthedocs.io/en/latest/) and the `py-pkgs-cookiecutter` [template](https://github.com/py-pkgs/py-pkgs-cookiecutter).

--- a/src/ghgql/ghgql.py
+++ b/src/ghgql/ghgql.py
@@ -8,6 +8,7 @@ This provides a simply class that can be used to query the Github GraphQL API.
 
 from typing import Dict, Union
 from requests import Session
+from requests.structures import CaseInsensitiveDict
 from .result import Result
 
 
@@ -34,6 +35,12 @@ class GithubGraphQL:
         self.__token = token
         self.__encoding = "utf-8"
         self.__session = Session()
+        self.__session.headers.update({
+            "Authorization": f"Bearer {self.token}",
+            # See #
+            # https://github.blog/2021-11-16-graphql-global-id-migration-update/
+            'X-Github-Next-Global-ID': '1'
+        })
 
     @property
     def token(self) -> str:
@@ -68,13 +75,12 @@ class GithubGraphQL:
         return self.query(query, variables)
 
     def __enter__(self):
-        self.__session.headers.update({
-            "Authorization": f"Bearer {self.token}",
-            # See #
-            # https://github.blog/2021-11-16-graphql-global-id-migration-update/
-            'X-Github-Next-Global-ID': '1'
-        })
         return self
+
+    @property
+    def session_headers(self) -> CaseInsensitiveDict:
+        """ Returns the HTTP headers used for the session. """
+        return self.__session.headers
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()

--- a/tests/test_githubgraphql.py
+++ b/tests/test_githubgraphql.py
@@ -127,6 +127,16 @@ class TestGithubGraphQL(unittest.TestCase):
                 self.assertEqual(actual, expected)
                 self.assertIsInstance(actual, ghgql.Result)
 
+    # Test for https://github.com/kwk/ghgql/issues/4
+    def test_session_headers_have_token_set(self):
+        """ Test that the session is properly equiped with a bearer token in the
+        header when the GithubGraphQL object is instantiated without a context
+        manager. """
+        ghapi = ghgql.GithubGraphQL(token="foobar")
+        headers = ghapi.session_headers
+        self.assertTrue("Authorization" in headers, "session headers are missing Authorization")
+        self.assertEqual(headers["Authorization"], "Bearer foobar", "Authorization token in session headers mismatch")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/kwk/ghgql/issues/4 (Token not set to the session if not used as a contextmanager)